### PR TITLE
Add support for Express.js querystring parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ useful when building an API and accepting various user specificed queries.
 | not exists | `?foo=!`     | `{ foo: { $exists: false }}` |
 | greater than | `?foo=>10` | `{ foo: { $gt: 10 }}` |
 | less than | `?foo=<10`    | `{ foo: { $lt: 10 }}` |
-| starts with | `?foo=^bar` | `{ foo: { $regex: "^foo", $options: "i" }}` |
-| ends with | `?foo=$bar`   | `{ foo: { $regex: "foo$", $options: "i" }}` |
-| contains  | `?foo=~bar`   | `{ foo: { $regex: "foo", $options: "i" }}` |
+| starts with | `?foo=^bar` | `{ foo: { $regex: "^bar", $options: "i" }}` |
+| ends with | `?foo=$bar`   | `{ foo: { $regex: "bar$", $options: "i" }}` |
+| contains  | `?foo=~bar`   | `{ foo: { $regex: "bar", $options: "i" }}` |
 | in array  | `?foo[]=bar&foo[]=baz` | `{ foo: { $in: ['bar', 'baz'] }}` |
 | not in array | `?foo[]=!bar&foo[]=!baz` | `{ foo: { $nin: ['bar', 'baz'] }}` |
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ useful when building an API and accepting various user specificed queries.
 
 | operation | query string  | query object |
 |-----------|---------------|--------------|
-| bbox | `?bbox=~0,1,2,3` | `{ geojson: { $geoWithin: { $geometry: { … } } } }` |
-| near | `?near=~0,1` | `{ geojson: { $near: { $geometry: { … } } } }` |
+| bbox | `?bbox=0,1,2,3` | `{ geojson: { $geoWithin: { $geometry: { … } } } }` |
+| near | `?near=0,1` | `{ geojson: { $near: { $geometry: { … } } } }` |
 
 * Custom query functions
   * `after` (date)

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function MongoQS(opts) {
   this.custom = opts.custom || {};
 
   this.keyRegex = opts.keyRegex || /^[a-zæøå0-9-_.]+$/i;
-  this.arrRegex = opts.arrRegex || /^[a-zæøå0-9-_.]+\[\]$/i;
+  this.arrRegex = opts.arrRegex || /^[a-zæøå0-9-_.]+(\[\])?$/i;
 
   for (var param in this.custom) {
     switch (param) {
@@ -129,8 +129,9 @@ module.exports.prototype.parse = function(query) {
 
     // array key
     if (val instanceof Array && this.arrRegex.test(key)) {
-      if (this.ops.indexOf('$in') >= 0) {
-        key = key.substr(0, key.length-2);
+      if (this.ops.indexOf('$in') >= 0 && val.length > 0) {
+        // remove [] at end of key name (unless it has already been removed)
+        key = key.replace(/\[\]$/, '');
 
         // $in query
         if (val[0][0] !== '!') {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "jshint": "^2.8.0",
     "mocha": "^2.3.4",
+    "qs": "^5.2.0",
     "semantic-release": "^4.3.5"
   }
 }

--- a/test.js
+++ b/test.js
@@ -299,7 +299,7 @@ describe('parse()', function() {
         });
       });
 
-      it('returns in array query with "qs" parser module (GH-06)', function() {
+      it('returns in array query with "qs" parser (GH-06)', function() {
         var string = 'foo[]=10&foo[]=10.011&foo[]=bar';
         var params = require('qs').parse(string);
 
@@ -332,7 +332,7 @@ describe('parse()', function() {
         });
       });
 
-      it('returns not in array query with "gs" parser module (GH-06)', function() {
+      it('returns not in array query with "gs" parser (GH-06)', function() {
         var string = 'foo[]=!10&foo[]=!10.011&foo[]=!bar';
         var params = require('qs').parse(string);
 

--- a/test.js
+++ b/test.js
@@ -299,6 +299,17 @@ describe('parse()', function() {
         });
       });
 
+      it('returns in array query with "qs" parser module (GH-06)', function() {
+        var string = 'foo[]=10&foo[]=10.011&foo[]=bar';
+        var params = require('qs').parse(string);
+
+        assert.deepEqual(qs.parse(params), {
+          foo: {
+            $in: [10, 10.011, 'bar']
+          }
+        });
+      });
+
       it('returns in array without any not in array query', function() {
         var string = 'foo[]=10&foo[]=!10.011&foo[]=!bar&foo[]=baz';
         var params = require('querystring').parse(string);
@@ -320,6 +331,18 @@ describe('parse()', function() {
           }
         });
       });
+
+      it('returns not in array query with "gs" parser module (GH-06)', function() {
+        var string = 'foo[]=!10&foo[]=!10.011&foo[]=!bar';
+        var params = require('qs').parse(string);
+
+        assert.deepEqual(qs.parse(params), {
+          foo: {
+            $nin: [10, 10.011, 'bar']
+          }
+        });
+      });
+
 
       it('returns not in array without any in array query', function() {
         var string = 'foo[]=!10&foo[]=10.011&foo[]=bar&foo[]=!baz';


### PR DESCRIPTION
This PR adds support for the default query string parser used in Express.js and Hapi.js. 