### PR TITLE
Add support for boolean operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ useful when building an API and accepting various user specificed queries.
 |-----------|---------------|--------------|
 | equal     | `?foo=bar`    | `{ foo: "bar" }` |
 | unequal   | `?foo=!bar`   | `{ foo: { $ne: "bar" }}` |
+| boolean   | `?foo=:true`  | `{ foo: true }` |
 | exists    | `?foo=`       | `{ foo: { $exists: true }}` |
 | not exists | `?foo=!`     | `{ foo: { $exists: false }}` |
 | greater than | `?foo=>10` | `{ foo: { $gt: 10 }}` |

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 module.exports = function MongoQS(opts) {
   opts = opts || {};
 
-  this.ops = opts.ops || ['!', '^', '$', '~', '>', '<', '$in'];
+  this.ops = opts.ops || ['!', '^', '$', '~', '>', '<', '$in', ':'];
   this.alias = opts.alias || {};
   this.blacklist = opts.blacklist || {};
   this.whitelist = opts.whitelist || {};
@@ -176,6 +176,13 @@ module.exports.prototype.parse = function(query) {
               return { $ne: isNaN(val) ? val : parseFloat(val, 10) };
             } else {
               return { $exists: false };
+            }
+            break;
+          case ':': 
+            if(val == "false") {
+              return false;
+            } else {
+              return true;
             }
             break;
           case '>':


### PR DESCRIPTION
During development I found that "true" and "false" are always converted into strings, leaving no ability to compare against booleans.

This patch adds support for bools through the ```:``` operator.

EX:

```
?param=:true
```