### PR TITLE
Use Node.js v4 LTS 'Argon'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ mongo:
     image: mongo:latest
 
 dev:
-  image: node:0.10-slim
+  image: node:argon
   links:
     - mongo
   working_dir: /usr/src/app
@@ -11,4 +11,3 @@ dev:
   command: "npm run watch"
   environment:
     - NODE_ENV=development
-    - NPM_CONFIG_LOGLEVEL=info

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: node:0.10
+box: node:argon
 
 services:
     - mongo:latest


### PR DESCRIPTION
Use Node.js v4 LTS 'Argon' for dev and test environments.