### PR TITLE
Add 'or equal to' operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ useful when building an API and accepting various user specificed queries.
 * Basic operators
   * `$eq`
   * `$gt`
+  * `$gte`
   * `$lt`
+  * `$lte`
   * `$ne`
   * `$in`
   * `$nin`
@@ -34,6 +36,8 @@ useful when building an API and accepting various user specificed queries.
 | not exists | `?foo=!`     | `{ foo: { $exists: false }}` |
 | greater than | `?foo=>10` | `{ foo: { $gt: 10 }}` |
 | less than | `?foo=<10`    | `{ foo: { $lt: 10 }}` |
+| greater than or equal to | `?foo=>=10` | `{ foo: { $gte: 10 }}` |
+| less than or equal to | `?foo=<=10`    | `{ foo: { $lte: 10 }}` |
 | starts with | `?foo=^bar` | `{ foo: { $regex: "^bar", $options: "i" }}` |
 | ends with | `?foo=$bar`   | `{ foo: { $regex: "bar$", $options: "i" }}` |
 | contains  | `?foo=~bar`   | `{ foo: { $regex: "bar", $options: "i" }}` |

--- a/examples/data.json
+++ b/examples/data.json
@@ -1,5 +1,6 @@
 [{
   "name": "Solrenningen",
+  "visits": 40,
   "geojson": {
     "type": "Point",
     "coordinates": [6.13037, 61.00607]
@@ -7,6 +8,7 @@
   "tags": ["Ved", "Mat", "Båt"]
 },{
   "name": "Norddalshytten",
+  "visits": 5571,
   "geojson": {
     "type": "Point",
     "coordinates": [5.99579, 61.01340]
@@ -14,6 +16,7 @@
   "tags": ["Ved", "Mat", "Tåke"]
 },{
   "name": "Åsedalen",
+  "visits": 10000,
   "geojson": {
     "type": "Point",
     "coordinates": [6.22032, 60.96244]
@@ -21,6 +24,7 @@
   "tags": ["Ved", "Mat", "Stekeovn"]
 },{
   "name": "Vatnane",
+  "visits": 9290,
   "geojson": {
     "type": "Point",
     "coordinates": [6.32607, 61.02105]
@@ -28,6 +32,7 @@
   "tags": ["Ved"]
 },{
   "name": "Selhamar",
+  "visits": 301,
   "geojson": {
     "type": "Point",
     "coordinates": [6.26495, 60.91275]
@@ -35,6 +40,7 @@
   "tags": ["Ved", "Mat", "Stekeovn", "Båt"]
 },{
   "name": "Vardadalsbu",
+  "visits": 30149,
   "geojson": {
     "type": "Point",
     "coordinates": [5.89279, 60.94477]

--- a/examples/test.js
+++ b/examples/test.js
@@ -76,7 +76,7 @@ describe('Example App', function() {
       .end(done);
   });
 
-  it('returns palces with any of the following tags', function(done) {
+  it('returns places with any of the following tags', function(done) {
     app.get(url + '?tags[]=Båt&tags[]=Stekeovn')
       .expect(200)
       .expect(function(res) {
@@ -84,6 +84,46 @@ describe('Example App', function() {
         assert.equal(res.body[0].name, 'Solrenningen');
         assert.equal(res.body[1].name, 'Åsedalen');
         assert.equal(res.body[2].name, 'Selhamar');
+      })
+      .end(done);
+  });
+
+  it('returns places with visits less than 40', function(done) {
+    app.get(url + '?visits=<40')
+      .expect(200)
+      .expect(function(res) {
+        assert.equal(res.body.length, 0);
+      })
+      .end(done);
+  });
+
+  it('returns places with visits less than or equal to 40', function(done) {
+    app.get(url + '?visits=<=40')
+      .expect(200)
+      .expect(function(res) {
+        assert.equal(res.body.length, 1);
+        assert.equal(res.body[0].name, 'Solrenningen');
+      })
+      .end(done);
+  });
+
+  it('returns places with visits greater than 10,000', function(done) {
+    app.get(url + '?visits=>10000')
+      .expect(200)
+      .expect(function(res) {
+        assert.equal(res.body.length, 1);
+        assert.equal(res.body[0].name, 'Vardadalsbu');
+      })
+      .end(done);
+  });
+
+  it('returns places with visits greater than or equal to 10,000', function(done) {
+    app.get(url + '?visits=>=10000')
+      .expect(200)
+      .expect(function(res) {
+        assert.equal(res.body.length, 2);
+        assert.equal(res.body[0].name, 'Åsedalen');
+        assert.equal(res.body[1].name, 'Vardadalsbu');
       })
       .end(done);
   });

--- a/index.js
+++ b/index.js
@@ -187,6 +187,8 @@ module.exports.prototype.parse = function(query) {
       val = val.substr(1);
 
       res[key] = (function() {
+        var hasEqual = (val.charAt(0) === '=');
+        var output = parseFloat((hasEqual ? val.substr(1) : val), 10);
         switch (op) {
           case '!':
             if (val) {
@@ -196,9 +198,9 @@ module.exports.prototype.parse = function(query) {
             }
             break;
           case '>':
-            return { $gt: parseFloat(val, 10) };
+            return output ? hasEqual ? { $gte: output } : { $gt: output } : {};
           case '<':
-            return { $lt: parseFloat(val, 10) };
+            return output ? hasEqual ? { $lte: output } : { $lt: output } : {};
           default:
             val = val.replace(/[^a-zæøå0-9-_.* ]/i, '');
             switch (op) {

--- a/test.js
+++ b/test.js
@@ -297,6 +297,34 @@ describe('parse()', function() {
       });
     });
 
+    describe('>= operator', function() {
+      it('returns greater than or equal to query', function() {
+        query = qs.parse({
+          navn: '>=10.110'
+        });
+        assert.deepEqual(query, {
+          navn: {
+            $gte: 10.110
+          }
+        });
+        return assert.strictEqual(query.navn.$gte, 10.110);
+      });
+    });
+
+    describe('>= operator', function() {
+      it('returns greater than or equal to query', function() {
+        query = qs.parse({
+          navn: '>=10.110'
+        });
+        assert.deepEqual(query, {
+          navn: {
+            $gte: 10.110
+          }
+        });
+        return assert.strictEqual(query.navn.$gte, 10.110);
+      });
+    });
+
     describe('< operator', function() {
       it('returns less than query', function() {
         query = qs.parse({
@@ -308,6 +336,34 @@ describe('parse()', function() {
           }
         });
         assert.strictEqual(query.navn.$lt, 10.110);
+      });
+    });
+
+    describe('<= operator', function() {
+      it('returns less than query or equal to', function() {
+        query = qs.parse({
+          navn: '<=10.110'
+        });
+        assert.deepEqual(query, {
+          navn: {
+            $lte: 10.110
+          }
+        });
+        assert.strictEqual(query.navn.$lte, 10.110);
+      });
+    });
+
+    describe('<= operator', function() {
+      it('returns less than query or equal to', function() {
+        query = qs.parse({
+          navn: '<=10.110'
+        });
+        assert.deepEqual(query, {
+          navn: {
+            $lte: 10.110
+          }
+        });
+        assert.strictEqual(query.navn.$lte, 10.110);
       });
     });
 


### PR DESCRIPTION
Allows query to include `$gte` and `$lte`. Fixes #13 .

This is the correct PR, reject the other one please :+1: 