### PR TITLE
Escape pipe in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ useful when building an API and accepting various user specificed queries.
 | after | `?after=1388534400` | `{ endret: { $gte: "2014-01-01T00:00:00.000Z" } }` |
 | before | `?before=2014-01-01` | `{ endret: { $lt: "2014-01-01T00:00:00.000Z" } }` |
 | before | `?before=1388534400` | `{ endret: { $lt: "2014-01-01T00:00:00.000Z" } }` |
-| between | `?between=2014-01-01|2015-01-01` | `{ endret: { $gte: "2014-01-01T00:00:00.000Z", $lt: "2015-01-01T00:00:00.000Z" } }` |
-| between | `?between=1388534400|1420088400` | `{ endret: { $gte: "2014-01-01T00:00:00.000Z", $lt: "2015-01-01T00:00:00.000Z" } }` |
+| between | `?between=2014-01-01\|2015-01-01` | `{ endret: { $gte: "2014-01-01T00:00:00.000Z", $lt: "2015-01-01T00:00:00.000Z" } }` |
+| between | `?between=1388534400\|1420088400` | `{ endret: { $gte: "2014-01-01T00:00:00.000Z", $lt: "2015-01-01T00:00:00.000Z" } }` |
 
 ## Install
 


### PR DESCRIPTION
Escapes the pipe character in the `between` dates example