### PR TITLE
Support for querying within a polygon

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -15,6 +15,7 @@ const qs = new MongoQS({
   custom: {
     bbox: 'geojson',
     near: 'geojson',
+    within: 'geojson',
   },
 });
 

--- a/examples/test.js
+++ b/examples/test.js
@@ -99,6 +99,34 @@ describe('Example App', () => {
       .end(done);
   });
 
+  it('returns places inside polygon', (done) => {
+    const polygon = [
+      5.9490966796875,
+      61.025705069868856,
+      5.987548828125,
+      60.994423108456154,
+      6.10565185546875,
+      60.98376689595989,
+      6.1962890625,
+      61.016390262027116,
+      6.115264892578125,
+      61.04964487995011,
+      5.969696044921875,
+      61.0516390483921,
+      5.9490966796875,
+      61.025705069868856,
+    ].join(',');
+
+    app.get(`${url}?within=${polygon}`)
+      .expect(200)
+      .expect((res) => {
+        assert.equal(res.body.length, 2);
+        assert.equal(res.body[0].name, 'Solrenningen');
+        assert.equal(res.body[1].name, 'Norddalshytten');
+      })
+      .end(done);
+  });
+
   it('returns places with any of the following tags', (done) => {
     app.get(`${url}?tags[]=Båt&tags[]=Stekeovn`)
       .expect(200)

--- a/test.js
+++ b/test.js
@@ -43,6 +43,45 @@ describe('customBBOX()', () => {
   });
 });
 
+describe('customWithin()', () => {
+  it('does not return $geoWithin query for invalid polygon', () => {
+    [
+      // non matching first last
+      '1,1,2,2,2,3,1,2,2,2',
+      // not enough points
+      '1,1,2,2,2,3',
+      // odd length
+      '1,1,2,2,2,3,1',
+      // invalid value
+      '1,1,2,2,2,3,1,2,2,a',
+    ].forEach((polygon) => {
+      mqs.customWithin('gojson')(query, polygon);
+      assert.deepEqual(query, {});
+    });
+  });
+
+  it('returns $geoWithin query for valid polygon', () => {
+    const string = '1,1,2,2,2,3,1,2,1,1';
+    mqs.customWithin('geojson')(query, string);
+    assert.deepEqual(query, {
+      geojson: {
+        $geoWithin: {
+          $geometry: {
+            type: 'Polygon',
+            coordinates: [[
+              [1, 1],
+              [2, 2],
+              [2, 3],
+              [1, 2],
+              [1, 1],
+            ]],
+          },
+        },
+      },
+    });
+  });
+});
+
 describe('customNear()', () => {
   it('does not return $near query for invalid point', () => {
     ['0123', '0,'].forEach((bbox) => {
@@ -103,6 +142,45 @@ describe('customNear()', () => {
           },
         },
       });
+    });
+  });
+});
+
+describe('customWithin()', () => {
+  it('does not return $geoWithin query for invalid polygon', () => {
+    [
+      // non matching first last
+      '1,1,2,2,2,3,1,2,2,2',
+      // not enough points
+      '1,1,2,2,2,3',
+      // odd length
+      '1,1,2,2,2,3,1',
+      // invalid value
+      '1,1,2,2,2,3,1,2,2,a',
+    ].forEach((polygon) => {
+      mqs.customWithin('gojson')(query, polygon);
+      assert.deepEqual(query, {});
+    });
+  });
+
+  it('returns $geoWithin query for valid polygon', () => {
+    const string = '1,1,2,2,2,3,1,2,1,1';
+    mqs.customWithin('geojson')(query, string);
+    assert.deepEqual(query, {
+      geojson: {
+        $geoWithin: {
+          $geometry: {
+            type: 'Polygon',
+            coordinates: [[
+              [1, 1],
+              [2, 2],
+              [2, 3],
+              [1, 2],
+              [1, 1],
+            ]],
+          },
+        },
+      },
     });
   });
 });


### PR DESCRIPTION
Adds support for querying within a polygon. String format is as follows:

`?within=1,1,2,2,2,3,1,2,1,1`

Thanks to @MadisonBlake for the logic, I just integrated it into the module 👍 

### Todo

* [ ] Documentation
* [ ] Fix up code-style issues